### PR TITLE
Allow scrolling of single page pdfs

### DIFF
--- a/ignore.template
+++ b/ignore.template
@@ -1,2 +1,2 @@
-./node_modules
+node_modules
 .git

--- a/index.js
+++ b/index.js
@@ -33,8 +33,7 @@ var SimplePDF = function (_React$Component) {
     _classCallCheck(this, SimplePDF);
 
     // bind
-
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(SimplePDF).call(this, props));
+    var _this = _possibleConstructorReturn(this, (SimplePDF.__proto__ || Object.getPrototypeOf(SimplePDF)).call(this, props));
 
     _this.loadPDF = _this.loadPDF.bind(_this);
     return _this;
@@ -59,8 +58,10 @@ var SimplePDF = function (_React$Component) {
 
       _pdfCombined2.default.getDocument(this.props.file).then(function (pdf) {
 
+        var onePageScrolling = this.props.onePageScrolling || false;
+
         // no scrollbar if pdf has only one page
-        if (pdf.numPages === 1) {
+        if (pdf.numPages === 1 && !this.props.onePageScrolling) {
           node.style.overflowY = "hidden";
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,10 @@ export default class SimplePDF extends React.Component {
 
     PDF.getDocument(this.props.file).then(function(pdf) {
 
+	  var onePageScrolling = this.props.onePageScrolling || false;
+
       // no scrollbar if pdf has only one page
-      if (pdf.numPages===1) {
+      if (pdf.numPages===1 && !this.props.onePageScrolling) {
         node.style.overflowY = "hidden";
       }
 


### PR DESCRIPTION
This can come in handy if you render a simplePDF component and the height of the single pdf page does not fit in the viewport. 