### PR TITLE
Allow onError function to be passed as a prop.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,7 @@ var SimplePDF = function (_React$Component) {
     _classCallCheck(this, SimplePDF);
 
     // bind
-
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(SimplePDF).call(this, props));
+    var _this = _possibleConstructorReturn(this, (SimplePDF.__proto__ || Object.getPrototypeOf(SimplePDF)).call(this, props));
 
     _this.loadPDF = _this.loadPDF.bind(_this);
     return _this;
@@ -90,7 +89,7 @@ var SimplePDF = function (_React$Component) {
             page.render(renderContext);
           });
         }
-      });
+      }).catch(this.props.onError);
     }
   }, {
     key: 'render',
@@ -118,5 +117,10 @@ var SimplePDF = function (_React$Component) {
 
 exports.default = SimplePDF;
 
+
+SimplePDF.defaultProps = {
+  onError: function onError() {},
+  file: null
+};
 
 module.exports = { SimplePDF: SimplePDF };

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export default class SimplePDF extends React.Component {
           page.render(renderContext);
         });
       }
-    });
+    }).catch(this.props.onError);
   }
 
   render() {
@@ -78,5 +78,10 @@ export default class SimplePDF extends React.Component {
     this.loadPDF();
   }
 }
+
+SimplePDF.defaultProps = {
+ onError: () => {},
+ file: null,
+};
 
 module.exports = { SimplePDF: SimplePDF };


### PR DESCRIPTION
Called when pdfjs's getDocument promise encounters an error.
useful for detecting when the pdf failed to load/render.